### PR TITLE
Allow multiple annotation/extension fields

### DIFF
--- a/examples/basic/Basic.hs
+++ b/examples/basic/Basic.hs
@@ -3,7 +3,7 @@ import BasicBase
 
 data NoExt
 
-extendA "A" [] [t|NoExt|] defaultExtA
+extendA "A" [] [t|NoExt|] $ \_ -> defaultExtA
 
 deriving instance Show a => Show (A a)
 

--- a/examples/deriv/Deriv.hs
+++ b/examples/deriv/Deriv.hs
@@ -4,7 +4,7 @@ import DerivBase
 data T
 
 extendA "A" [] [t|T|] $ defaultExtA {
-    typeA = Ann $ \a -> [t| [$a] |]
+    typeA = Ann [\a -> [t| [$a] |]]
   }
 
 extendB "B" [] [t|T|] $ defaultExtB

--- a/examples/deriv/Deriv.hs
+++ b/examples/deriv/Deriv.hs
@@ -5,7 +5,7 @@ data T
 
 extendA "A" [] [t|T|] $
   \a -> defaultExtA {
-    typeA = Ann [[t| [$a] |]]
+    typeA = Just [[t| [$a] |]]
   }
 
 extendB "B" [] [t|T|] $ \_ -> defaultExtB

--- a/examples/deriv/Deriv.hs
+++ b/examples/deriv/Deriv.hs
@@ -3,11 +3,12 @@ import DerivBase
 
 data T
 
-extendA "A" [] [t|T|] $ defaultExtA {
-    typeA = Ann [\a -> [t| [$a] |]]
+extendA "A" [] [t|T|] $
+  \a -> defaultExtA {
+    typeA = Ann [[t| [$a] |]]
   }
 
-extendB "B" [] [t|T|] $ defaultExtB
+extendB "B" [] [t|T|] $ \_ -> defaultExtB
 
 main :: IO ()
 main = print $

--- a/examples/lam/DeBruijn.hs
+++ b/examples/lam/DeBruijn.hs
@@ -1,0 +1,14 @@
+module DeBruijn where
+import LamBase
+
+data DeBruijn
+
+extendLam "DBTerm" [] [t|DeBruijn|] $
+  \a p -> defaultExtLam {
+    typeVar = Nothing, -- replaced with Free and Bound
+    typeAbs = Nothing, -- replaced with a version without absVar
+    typeLamX =
+      [("Free",  [("freeVar", a)]),
+       ("Bound", [("boundVar", [t|Int|])]),
+       ("Abs",   [("absBody",  [t|Lam' DeBruijn $a $p|])])]
+  }

--- a/examples/lam/Lam.hs
+++ b/examples/lam/Lam.hs
@@ -1,23 +1,6 @@
-import LamBase
-import Extensible
-
-data NoExt
-
-data Type t =
-    Base t
-  | Arr (Type t) (Type t)
-
-data Typed t
-
-do t' <- newName "t"; let t = varT t'
-   extendLam "TypedLam" [t'] [t|Typed $t|] $
-     \a p -> defaultExtLam {
-       typeVar = Just [("varType", [t|Type $t|])],
-       typeAbs = Just [("absArg",  [t|Type $t|])],
-       typeLamX = [("TypeAnn",
-          [("annTerm", [t|Lam' (Typed $t) $a $p|]),
-           ("annType", [t|Type $t|])])]
-     }
+import LamBase  ()
+import Typed    ()
+import DeBruijn ()
 
 main :: IO ()
 main = pure ()

--- a/examples/lam/Lam.hs
+++ b/examples/lam/Lam.hs
@@ -1,0 +1,23 @@
+import LamBase
+import Extensible
+
+data NoExt
+
+data Type t =
+    Base t
+  | Arr (Type t) (Type t)
+
+data Typed t
+
+do t' <- newName "t"; let t = varT t'
+   extendLam "TypedLam" [t'] [t|Typed $t|] $
+     \a p -> defaultExtLam {
+       typeVar = Just [("varType", [t|Type $t|])],
+       typeAbs = Just [("absArg",  [t|Type $t|])],
+       typeLamX = [("TypeAnn",
+          [("annTerm", [t|Lam' (Typed $t) $a $p|]),
+           ("annType", [t|Type $t|])])]
+     }
+
+main :: IO ()
+main = pure ()

--- a/examples/lam/LamBase.hs
+++ b/examples/lam/LamBase.hs
@@ -1,0 +1,11 @@
+module LamBase where
+import Extensible
+
+extensible [d|
+  data Lam a p =
+      Var {varVar :: a}
+    | Prim {primVal :: p}
+    | App {appFun, appArg :: Lam a p}
+    | Abs {absVar :: a, absBody :: Lam a p}
+    deriving (Eq, Show)
+  |]

--- a/examples/lam/Typed.hs
+++ b/examples/lam/Typed.hs
@@ -1,0 +1,24 @@
+module Typed where
+import LamBase
+import Extensible
+
+data NoExt
+
+data Type t =
+    Base t
+  | Arr (Type t) (Type t)
+
+data Typed t
+
+do t' <- newName "t"; let t = varT t'
+   extendLam "TypedLam" [t'] [t|Typed $t|] $
+     \a p -> defaultExtLam {
+       typeVar = Just [("varType", [t|Type $t|])],
+       typeAbs = Just [("absArg",  [t|Type $t|])],
+       typeLamX = [("TypeAnn",
+          [("annTerm", [t|Lam' (Typed $t) $a $p|]),
+           ("annType", [t|Type $t|])])]
+     }
+
+main :: IO ()
+main = pure ()

--- a/examples/multifield/MultiField.hs
+++ b/examples/multifield/MultiField.hs
@@ -1,0 +1,16 @@
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
+import MultiFieldBase
+
+extendA "A" [] [t|Int|] $
+  \a -> defaultExtA {
+    typeA = Just [[t|Int|], [t|$a|]],
+    typeB = Nothing,
+    typeAX = [("C", [[t|Bool|], [t|Char|]])]
+  }
+
+foo :: A () -> ()
+foo (A u₁ i u₂) = () where _ = (u₁ :: (), i :: Int, u₂ :: ())
+foo (C b c)     = () where _ = (b :: Bool, c :: Char)
+
+main :: IO ()
+main = pure ()

--- a/examples/multifield/MultiFieldBase.hs
+++ b/examples/multifield/MultiFieldBase.hs
@@ -1,0 +1,4 @@
+module MultiFieldBase where
+import Extensible
+
+extensible [d| data A a = A a | B (A a) (A Int) |]

--- a/examples/mutual/Mutual.hs
+++ b/examples/mutual/Mutual.hs
@@ -4,11 +4,11 @@ import MutualBase
 data Ext
 
 extendA "A" [] [t|Ext|] defaultExtA {
-  typeAX = [("AI", [t|Int|])]
+  typeAX = [("AI", [[t|Int|]])]
 }
 
 extendB "B" [] [t|Ext|] defaultExtB {
-  typeBA = Ann [t|String|]
+  typeBA = Ann [[t|String|]]
 }
 
 main :: IO ()

--- a/examples/mutual/Mutual.hs
+++ b/examples/mutual/Mutual.hs
@@ -8,7 +8,7 @@ extendA "A" [] [t|Ext|] defaultExtA {
 }
 
 extendB "B" [] [t|Ext|] defaultExtB {
-  typeBA = Ann [[t|String|]]
+  typeBA = Just [[t|String|]]
 }
 
 main :: IO ()

--- a/examples/param/Param.hs
+++ b/examples/param/Param.hs
@@ -6,7 +6,7 @@ data With a
 do an <- newName "a"
    let a = varT an
    extendT "T" [an] [t|With $a|] $ defaultExtT {
-     typeTX = [("Extra", a)]
+     typeTX = [("Extra", [a])]
    }
 
 main :: IO ()

--- a/examples/qualified/Qualified.hs
+++ b/examples/qualified/Qualified.hs
@@ -1,7 +1,7 @@
 import qualified QualifiedBase
 
 QualifiedBase.extendT "T" [] [t|()|] $ QualifiedBase.defaultExtT {
-  QualifiedBase.typeTX = [("C", [t|Char|])]
+  QualifiedBase.typeTX = [("C", [[t|Char|]])]
 }
 
 main :: IO ()

--- a/examples/record/Record.hs
+++ b/examples/record/Record.hs
@@ -7,9 +7,9 @@ data WithString
 
 R.extendRec "Rec" [] [t|WithString|] $
   R.defaultExtRec {
-    R.typeR1 = Ann ("label1", [t|String|]),
-    R.typeR2 = Ann ("label2", [t|String|]),
-    R.typeRecX = [("R3", "contents", [t|Int|])]
+    R.typeR1 = Ann [("label1", [t|String|])],
+    R.typeR2 = Ann [("label2", [t|String|])],
+    R.typeRecX = [("R3", [("contents", [t|Int|])])]
   }
 
 main :: IO ()

--- a/examples/record/Record.hs
+++ b/examples/record/Record.hs
@@ -7,8 +7,8 @@ data WithString
 
 R.extendRec "Rec" [] [t|WithString|] $
   R.defaultExtRec {
-    R.typeR1 = Ann [("label1", [t|String|])],
-    R.typeR2 = Ann [("label2", [t|String|])],
+    R.typeR1 = Just [("label1", [t|String|])],
+    R.typeR2 = Just [("label2", [t|String|])],
     R.typeRecX = [("R3", [("contents", [t|Int|])])]
   }
 

--- a/extensible-data.cabal
+++ b/extensible-data.cabal
@@ -100,3 +100,9 @@ executable multifield
   hs-source-dirs: examples/multifield
   main-is: MultiField.hs
   other-modules: MultiFieldBase
+
+executable lam
+  import: deps, example
+  hs-source-dirs: examples/lam
+  main-is: Lam.hs
+  other-modules: LamBase

--- a/extensible-data.cabal
+++ b/extensible-data.cabal
@@ -105,4 +105,4 @@ executable lam
   import: deps, example
   hs-source-dirs: examples/lam
   main-is: Lam.hs
-  other-modules: LamBase
+  other-modules: LamBase, Typed, DeBruijn

--- a/extensible-data.cabal
+++ b/extensible-data.cabal
@@ -94,3 +94,9 @@ executable record
   hs-source-dirs: examples/record
   main-is: Record.hs
   other-modules: RecordBase
+
+executable multifield
+  import: deps, example
+  hs-source-dirs: examples/multifield
+  main-is: MultiField.hs
+  other-modules: MultiFieldBase

--- a/src/Extensible.hs
+++ b/src/Extensible.hs
@@ -13,21 +13,21 @@
 -- * A type family is generated for each constructor, taking an argument named
 --   @ext@ for the extension type, followed by the arguments of the datatype.
 --   The names of the type families correspond to the constructors themselves
---   modified with 'annotationName' (see @<#XBar XBar>@ etc below).
+--   modified with 'annotationName' (see @<#XVar XVar>@ etc below).
 -- * An extra type family is generated with the same arguments, named after the
---   datatype modified with 'extensionName' (see @<#FooX FooX>@).
+--   datatype modified with 'extensionName' (see @<#LamX LamX>@).
 -- * The datatype itself is renamed according to 'datatypeName' and given an
 --   extra argument called @ext@ (before the others).
 -- * Each existing constructor is renamed according to 'constructorName', and
 --   given an extra strict field of the corresponding type family generated
 --   above.
 -- * An extra constructor is generated for the extension type family (with the
---   same name), containing it as its sole field (see @<#Foo' Foo'>@ for the
+--   same name), containing it as its sole field (see @<#Lam' Lam'>@ for the
 --   transformation).
 -- * A constraint synonym is generated, named according to 'bundleName', which
---   contains a constraint for each extension (see @<#FooAll FooAll>@).
+--   contains a constraint for each extension (see @<#LamAll LamAll>@).
 -- * A record and TH function are generated for creating new extensions of the
---   base datatype (see @<#FooExt FooExt>@ and @<#extendFoo extendFoo>@).
+--   base datatype (see @<#ExtLam ExtLam>@ and @<#extendLam extendLam>@).
 -- * A standalone @deriving@ declaration is generated for each derived instance
 --   listed.
 --

--- a/src/Extensible.hs
+++ b/src/Extensible.hs
@@ -128,7 +128,7 @@
 --   ExtLam {
 --     nameVar :: 'String', -- rename a constructor                      #nameVar#
 --     typeVar :: 'Maybe' [('String', 'TypeQ')],                         #typeVar#
---       -- a list of extra field namess and types
+--       -- a list of extra field names and types
 --       -- * for a non-record, this is a 'Maybe' ['TypeQ'] instead
 --       -- * Nothing disables the constructor
 --     namePrim :: 'String', typePrim :: 'Maybe' [('String', 'TypeQ')],  #namePrim# #typePrim#
@@ -157,9 +157,9 @@
 --           -> ['Name'] -- ^ extra type variables, if needed
 --           -> 'TypeQ'  -- ^ tag for this variant of the type
 --                     --   (the \"ext\" parameter; should contain the above vars)
---           -> ('TypeQ' -> <#ExtLam ExtLam>)
+--           -> ('TypeQ' -> 'TypeQ' -> <#ExtLam ExtLam>)
 --                     -- ^ description of extension
---                     --   (input is <#Lam Lam>'s \"a\" type variable)
+--                     --   (input is <#Lam Lam>'s type variables a and p)
 --           -> 'DecsQ'
 -- extendLam = ...
 -- @


### PR DESCRIPTION
- [x] Move lambdas in `extendFoo` for less repetition
- [x] Remove `ConAnn`, use `Maybe` instead (since now `NoAnn` is the same as `Ann []`)
- [x] Add example
- [x] Update documentation