### PR TITLE
Support type synonyms

### DIFF
--- a/examples/type-synonym/TypeSynonym.hs
+++ b/examples/type-synonym/TypeSynonym.hs
@@ -1,0 +1,10 @@
+import TypeSynonymBase
+
+data NoExt
+
+extendExp "Exp" [] [t|NoExt|] defaultExtExp
+extendArg "Arg" [] [t|NoExt|] defaultExtArg
+type Args = Args' NoExt
+
+main :: IO ()
+main = pure ()

--- a/examples/type-synonym/TypeSynonymBase.hs
+++ b/examples/type-synonym/TypeSynonymBase.hs
@@ -1,0 +1,8 @@
+module TypeSynonymBase where
+import Extensible
+
+extensible [d|
+    data Exp = App Exp Args | Var String
+    data Arg = Arg String Exp
+    type Args = [Arg]
+  |]

--- a/extensible-data.cabal
+++ b/extensible-data.cabal
@@ -101,6 +101,12 @@ executable multifield
   main-is: MultiField.hs
   other-modules: MultiFieldBase
 
+executable type-synonym
+  import: deps, example
+  hs-source-dirs: examples/type-synonym
+  main-is: TypeSynonym.hs
+  other-modules: TypeSynonymBase
+
 executable lam
   import: deps, example
   hs-source-dirs: examples/lam

--- a/src/Extensible.hs
+++ b/src/Extensible.hs
@@ -554,7 +554,7 @@ makeExtensible1 conf home nameMap (SimpleData name tvs cs derivs) = do
 makeExtensible1 _conf _home nameMap (SimpleType name tvs rhs) = do
   let Just name' = lookup name nameMap
   ext <- newName "ext"
-  pure [TySynD name' tvs $ extendRecursions nameMap ext rhs]
+  pure [TySynD name' (PlainTV ext : tvs) $ extendRecursions nameMap ext rhs]
 
 nonstrict :: BangQ
 nonstrict = bang noSourceUnpackedness noSourceStrictness

--- a/src/Extensible.hs
+++ b/src/Extensible.hs
@@ -281,7 +281,7 @@ import Generics.SYB (Data, everywhere, mkT)
 import Control.Monad
 import Data.Functor.Identity
 import Data.Void
-import Data.Kind as K
+import qualified Data.Kind as K
 
 -- ☹
 deriving instance Lift Name
@@ -609,7 +609,7 @@ constraintBundle :: Config
                  -> [TyVarBndr] -> [SimpleCon] -> DecQ
 constraintBundle conf name ext tvs cs = do
   c <- newName "c"
-  ckind <- [t|K.Type -> Constraint|]
+  ckind <- [t|K.Type -> K.Constraint|]
   let cnames = map scName cs
       bname  = applyAffix (bundleName conf) name
       tvs'   = kindedTV c ckind : plainTV ext : tvs


### PR DESCRIPTION
Fixes #10.

- [x] add example

---

```
extensible [d|
    data Bar a = ...; data Baz a = ...
    type Foo a = [(Bar a, Baz String)]
  |]
====>
data Bar' ext a = ...; data Baz' ext a = ... -- etc
type Foo' ext a = [(Bar' ext a, Baz' ext String)]
```

There's no `extendFoo` generated since it'd just be

```
extendFoo "Foo" [t|A|]
====>
type Foo = Foo' A
````

which doesn't seem worth the effort